### PR TITLE
fix: type signature for full declaration

### DIFF
--- a/packages/bumpgen-core/src/services/language/typescript/__snapshots__/index.test.ts.snap
+++ b/packages/bumpgen-core/src/services/language/typescript/__snapshots__/index.test.ts.snap
@@ -140,14 +140,7 @@ exports[`dependencyGraphService initializes 1`] = `
     "name": "App",
     "path": "/test-project/src/app/index.tsx",
     "startLine": 4,
-    "typeSignature": "function App() {
-  return (
-    <div>
-      <h1>My React App</h1>
-      <MyNewComponent />
-    </div>
-  );
-}
+    "typeSignature": "() => JSX.Element
 ",
   },
   {
@@ -172,9 +165,22 @@ exports[`dependencyGraphService initializes 1`] = `
     "name": "MyNewComponent",
     "path": "/test-project/src/app/index.tsx",
     "startLine": 13,
-    "typeSignature": "function MyNewComponent() {
-  return <p>This is my new component</p>;
-}
+    "typeSignature": "() => JSX.Element
+",
+  },
+  {
+    "block": "export async function listDirectory(dir: string): Promise<null> {
+  console.log("Listing directory", dir);
+  return Promise.resolve(null);
+}",
+    "edits": [],
+    "endLine": 4,
+    "id": "2c69e417f3abb8fe23eec60a5a0241f706e58cec",
+    "kind": "FunctionDeclaration",
+    "name": "listDirectory",
+    "path": "/test-project/src/utils/dir.ts",
+    "startLine": 1,
+    "typeSignature": "(dir: string) => Promise<null>
 ",
   },
   {
@@ -312,11 +318,7 @@ type UseQueryResult<TData = unknown, TError = DefaultError> = UseBaseQueryResult
     "path": "/test-project/src/utils/index.ts",
     "startLine": 14,
     "typeSignature": "class NodeRelations  {
- constructor (hasCycle: boolean) => NodeRelations  NodeRelations.addEdge: addEdge() {
-    console.log("edge");
-    z.string();
-    return "";
-  }
+ constructor (hasCycle: boolean) => NodeRelations  NodeRelations.addEdge: () => string
 }",
   },
   {
@@ -332,11 +334,7 @@ type UseQueryResult<TData = unknown, TError = DefaultError> = UseBaseQueryResult
     "name": "myFunction",
     "path": "/test-project/src/utils/index.ts",
     "startLine": 34,
-    "typeSignature": "export function myFunction(text: string) {
-  z.string();
-  console.log(text);
-  return text;
-}
+    "typeSignature": "(text: string) => string
 ",
   },
   {

--- a/packages/bumpgen-core/src/services/language/typescript/__snapshots__/index.test.ts.snap
+++ b/packages/bumpgen-core/src/services/language/typescript/__snapshots__/index.test.ts.snap
@@ -16,12 +16,7 @@ exports[`dependencyGraphService initializes 1`] = `
     "name": "date",
     "path": "/test-project/src/index.ts",
     "startLine": 1,
-    "typeSignature": "date = () =>
-  z.string().transform((v) => {
-    const date = v.replace(/(\\\\d+)(st|nd|rd|th)/, "$1");
-    return isNaN(new Date(date).getTime()) ? undefined : new Date(date);
-  })
-",
+    "typeSignature": "() => Zod.ZodEffects<Zod.ZodString, Date | undefined, string>",
   },
   {
     "block": "import {
@@ -353,15 +348,7 @@ type UseQueryResult<TData = unknown, TError = DefaultError> = UseBaseQueryResult
     "name": "useQueryFn",
     "path": "/test-project/src/utils/index.ts",
     "startLine": 5,
-    "typeSignature": "useQueryFn = () => {
-  useQuery({
-    queryKey: ["key"],
-    queryFn: () => {
-      return "data";
-    },
-  });
-}
-",
+    "typeSignature": "() => void",
   },
   {
     "block": "export const date = () =>
@@ -376,12 +363,7 @@ type UseQueryResult<TData = unknown, TError = DefaultError> = UseBaseQueryResult
     "name": "date",
     "path": "/test-project/src/utils/index.ts",
     "startLine": 28,
-    "typeSignature": "date = () =>
-  z.string().transform((v) => {
-    const date = v.replace(/(\\\\d+)(st|nd|rd|th)/, "$1");
-    return isNaN(new Date(date).getTime()) ? undefined : new Date(date);
-  })
-",
+    "typeSignature": "() => Zod.ZodEffects<Zod.ZodString, Date | undefined, string>",
   },
 ]
 `;

--- a/packages/bumpgen-core/src/services/language/typescript/signatures.ts
+++ b/packages/bumpgen-core/src/services/language/typescript/signatures.ts
@@ -122,8 +122,21 @@ const functionDeclarationSignature = (node: FunctionDeclaration) => {
 };
 
 const variableDeclarationSignature = (node: VariableDeclaration) => {
-  const typeDef = node.getText();
-  return enrichWithTypeReferences(typeDef, node);
+  // check if the node is a type decalaration or the full implementation
+  if (node.getDescendantsOfKind(SyntaxKind.Block).length >= 1) {
+    // ref: https://github.com/dsherret/ts-morph/issues/907
+    return node
+      .getType()
+      .getText(
+        undefined,
+        TypeFormatFlags.UseFullyQualifiedType |
+          TypeFormatFlags.InTypeAlias |
+          TypeFormatFlags.NoTruncation,
+      );
+  } else {
+    const typeDef = node.getText();
+    return enrichWithTypeReferences(typeDef, node);
+  }
 };
 
 const methodDeclarationSignature = (node: MethodDeclaration) => {

--- a/packages/bumpgen-core/src/services/language/typescript/signatures.ts
+++ b/packages/bumpgen-core/src/services/language/typescript/signatures.ts
@@ -102,8 +102,23 @@ const indexSignatureDeclarationSignature = (
 };
 
 const functionDeclarationSignature = (node: FunctionDeclaration) => {
-  const typeDef = node.getText();
-  return enrichWithTypeReferences(typeDef, node);
+  // check if the node is a type decalaration or the full implementation
+  if (node.getDescendantsOfKind(SyntaxKind.Block).length >= 1) {
+    // ref: https://github.com/dsherret/ts-morph/issues/907
+    const params = node
+      .getParameters()
+      .map((parameter) => parameter.getText())
+      .join(", ");
+    const returnType = node.getReturnType().getText(
+      node,
+      // https://github.com/dsherret/ts-morph/issues/453#issuecomment-667578386
+      TypeFormatFlags.UseAliasDefinedOutsideCurrentScope,
+    );
+    return enrichWithTypeReferences(`(${params}) => ${returnType}`, node);
+  } else {
+    const typeDef = node.getText();
+    return enrichWithTypeReferences(typeDef, node);
+  }
 };
 
 const variableDeclarationSignature = (node: VariableDeclaration) => {
@@ -112,8 +127,19 @@ const variableDeclarationSignature = (node: VariableDeclaration) => {
 };
 
 const methodDeclarationSignature = (node: MethodDeclaration) => {
-  const typeDef = node.getText();
-  return enrichWithTypeReferences(typeDef, node);
+  // check if the node is a type decalaration or the full implementation
+  if (node.getDescendantsOfKind(SyntaxKind.Block).length >= 1) {
+    // ref: https://github.com/dsherret/ts-morph/issues/907
+    const params = node
+      .getParameters()
+      .map((parameter) => parameter.getText())
+      .join(", ");
+    const returnType = node.getReturnType().getText();
+    return enrichWithTypeReferences(`(${params}) => ${returnType}`, node);
+  } else {
+    const typeDef = node.getText();
+    return enrichWithTypeReferences(typeDef, node);
+  }
 };
 
 const heritageClauseSignature = (node: HeritageClause) => {

--- a/packages/test-project/src/utils/dir.ts
+++ b/packages/test-project/src/utils/dir.ts
@@ -1,0 +1,4 @@
+export async function listDirectory(dir: string): Promise<null> {
+  console.log("Listing directory", dir);
+  return Promise.resolve(null);
+}


### PR DESCRIPTION
somewhat of a revert for this earlier commit: https://github.com/xeol-io/bumpgen/commit/6f2c0d3244dd5007dc69c75646fa1385f4155754

we need to understand whether a function is a full declaration or a simple type declaration in order to return the correct types for it. we can do this by checking whether there is a `Block` element inside it, which a simple declaration will not have.